### PR TITLE
Allow to install in MAC OS Ventura (M1)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,7 +16,7 @@ _get_arch() {
 	arch="$(uname -m)"
 	case $arch in
 	"x86_64") arch="amd64" ;;
-	"Darwin arm64") arch="arm64" ;;
+	"arm64") arch="arm64" ;;
 	"x86_64") arch="amd64" ;;
 	"aarch64") arch="aarch64" ;;
 	*) arch="other" ;;


### PR DESCRIPTION
Allow to install in MAC OS Ventura (M1), when using MAC Ventura it wasn't possible to install, but after this change the installation was successful.

Taking advantage of this PR, I will thank you, because I took your code and created a fork for installing `oc`, if you are not comfortable with that, please let me know and I will remove.